### PR TITLE
修复文件夹错误

### DIFF
--- a/src/QiniuPlugin.es6
+++ b/src/QiniuPlugin.es6
@@ -1,5 +1,6 @@
 import qiniu from 'qiniu';
 import Promise from 'promise';
+import path from 'path';
 
 class QiniuPlugin {
   constructor(options) {
@@ -16,11 +17,11 @@ class QiniuPlugin {
       let hash = compilation.hash;
       let {
         bucket,
-        path = "[hash]",
+        dir = "[hash]",
         include,
       } = this.options;
       
-      path = path.replace("[hash]", hash);
+      dir = dir.replace("[hash]", hash);
       
       let promises = Object.keys(assets).filter(fileName=> {
         let valid = assets[fileName].emitted;
@@ -35,7 +36,7 @@ class QiniuPlugin {
         }
         return valid;
       }).map(fileName=> {
-        let key = `${path}${fileName}`;
+        let key = path.join(dir, fileName);
         let putPolicy = new qiniu.rs.PutPolicy(`${bucket}:${key}`);
         let token = putPolicy.token();
         let extra = new qiniu.io.PutExtra();

--- a/src/QiniuPlugin.es6
+++ b/src/QiniuPlugin.es6
@@ -1,6 +1,6 @@
 import qiniu from 'qiniu';
 import Promise from 'promise';
-import path from 'path';
+import {join} from 'path';
 
 class QiniuPlugin {
   constructor(options) {
@@ -17,11 +17,11 @@ class QiniuPlugin {
       let hash = compilation.hash;
       let {
         bucket,
-        dir = "[hash]",
+        path = "[hash]",
         include,
       } = this.options;
       
-      dir = dir.replace("[hash]", hash);
+      path = path.replace("[hash]", hash);
       
       let promises = Object.keys(assets).filter(fileName=> {
         let valid = assets[fileName].emitted;
@@ -36,7 +36,7 @@ class QiniuPlugin {
         }
         return valid;
       }).map(fileName=> {
-        let key = path.join(dir, fileName);
+        let key = join(path, fileName);
         let putPolicy = new qiniu.rs.PutPolicy(`${bucket}:${key}`);
         let token = putPolicy.token();
         let extra = new qiniu.io.PutExtra();

--- a/src/QiniuPlugin.es6
+++ b/src/QiniuPlugin.es6
@@ -35,7 +35,7 @@ class QiniuPlugin {
         }
         return valid;
       }).map(fileName=> {
-        let key = `${path}/${fileName}`;
+        let key = `${path}${fileName}`;
         let putPolicy = new qiniu.rs.PutPolicy(`${bucket}:${key}`);
         let token = putPolicy.token();
         let extra = new qiniu.io.PutExtra();


### PR DESCRIPTION
当path为空时，文件名为`/index.html`，应该为`index.html`，这样可以使用七牛的静态网站。